### PR TITLE
Jwaldor/tabdescriptor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -412,6 +412,37 @@ function HeatGrid({ heatvalues }: HeatProps) {
   );
 }
 
+type TabType = { name: string; picture: string; description: string };
+type TabProps = { tabs: [TabType, TabType, TabType]; currtab: number };
+
+function TabDescriptor({ tabs, currtab }: TabProps) {
+  return (
+    <>
+      <div className="flex flex-col w-[90%] max-w-sm text-center">
+        <div className="flex flex-row bg-[#eeecec] justify-around rounded-lg m-3">
+          {tabs.map((atab, index) => (
+            <div
+              className={`w-[30%] my-2 rounded-md ${
+                index === currtab ? "bg-white" : ""
+              }`}
+            >
+              {atab.name}
+            </div>
+          ))}
+        </div>
+        <div className="flex flex-col bg-white m-3 rounded-lg">
+          {/*  */}
+          <img
+            className="rounded-full w-40 h-40 object-cover m-4"
+            src={tabs[currtab].picture}
+          ></img>
+          <div className="m-2">{tabs[currtab].description}</div>
+        </div>
+      </div>
+    </>
+  );
+}
+
 function App() {
   const icon0 = "c3fa630880a17b97a1f864fb528f0aa2.png";
   const icon1 = "b0fbdd8e320622de39475b562ddad56d.png";
@@ -456,6 +487,29 @@ function App() {
     [3, 3, 1, 3, 2],
   ];
 
+  const tab_ex: [TabType, TabType, TabType] = [
+    {
+      name: "Nicki",
+      picture:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/1/15/Cat_August_2010-4.jpg/1200px-Cat_August_2010-4.jpg",
+      description:
+        "A 28-year-old software engineer who loves AI, hiking, and sci-fi novels. Enjoys traveling and trying new recipes.",
+    },
+    {
+      name: "Jake",
+      picture:
+        "https://cdn.britannica.com/34/235834-050-C5843610/two-different-breeds-of-cats-side-by-side-outdoors-in-the-garden.jpg",
+      description:
+        "A 35-year-old graphic designer who creates digital art, plays guitar, and practices yoga. Tech and gaming enthusiast.",
+    },
+    {
+      name: "Akame",
+      picture:
+        "https://static.vecteezy.com/system/resources/thumbnails/022/963/918/small_2x/ai-generative-cute-cat-isolated-on-solid-background-photo.jpg",
+      description: "Lorem ipsum dolor amit",
+    },
+  ];
+
   return (
     <>
       <div className="w-full min-h-full flex flex-col items-end">
@@ -486,6 +540,18 @@ function App() {
         />
       </div>
       <HeatGrid heatvalues={heatvalues} />
+      <div className="bg-gray-300">
+        <TabDescriptor tabs={tab_ex} currtab={0} />
+      </div>
+
+      <div className="flex flex-col bg-white m-3 rounded-lg justify-center">
+        {/*  */}
+        <img
+          className="rounded-full w-40 h-40 object-cover m-4"
+          src={tab_ex[0].picture}
+        ></img>
+        <div className="m-2">{tab_ex[0].description}</div>
+      </div>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -415,28 +415,30 @@ function HeatGrid({ heatvalues }: HeatProps) {
 type TabType = { name: string; picture: string; description: string };
 type TabProps = { tabs: [TabType, TabType, TabType]; currtab: number };
 
-function TabDescriptor({ tabs, currtab }: TabProps) {
+function TabDescriptor({ tabs }: TabProps) {
+  const [currtab, setCurrTab] = useState(0);
   return (
     <>
       <div className="flex flex-col w-[90%] max-w-sm text-center">
         <div className="flex flex-row bg-[#eeecec] justify-around rounded-lg m-3">
           {tabs.map((atab, index) => (
-            <div
-              className={`w-[30%] my-2 rounded-md ${
-                index === currtab ? "bg-white" : ""
-              }`}
+            <button
+              onClick={() => setCurrTab(index)}
+              className={`w-[30%] py-1 my-2 rounded-md ${
+                index !== currtab ? "hover:bg-gray-200" : ""
+              } ${index === currtab ? "bg-white" : ""}`}
             >
               {atab.name}
-            </div>
+            </button>
           ))}
         </div>
-        <div className="flex flex-col bg-white m-3 rounded-lg">
+        <div className="flex flex-col bg-white m-3 rounded-lg items-center p-1">
           {/*  */}
           <img
-            className="rounded-full w-40 h-40 object-cover m-4"
+            className="rounded-full w-40 h-40 object-cover mt-3 mb-3"
             src={tabs[currtab].picture}
           ></img>
-          <div className="m-2">{tabs[currtab].description}</div>
+          <div className="mt-3 mb-4 mx-4">{tabs[currtab].description}</div>
         </div>
       </div>
     </>
@@ -540,11 +542,11 @@ function App() {
         />
       </div>
       <HeatGrid heatvalues={heatvalues} />
-      <div className="bg-gray-300">
-        <TabDescriptor tabs={tab_ex} currtab={0} />
+      <div className="bg-gray-300 flex flex-col items-center">
+        <TabDescriptor tabs={tab_ex} />
       </div>
 
-      <div className="flex flex-col bg-white m-3 rounded-lg justify-center">
+      <div className="flex flex-col bg-white m-3 rounded-lg items-center">
         {/*  */}
         <img
           className="rounded-full w-40 h-40 object-cover m-4"


### PR DESCRIPTION
Done. Room for improvement:
getting text distribution to line up exactly with the Figma spec
addressing issue where small photos show up as rectangles with rounded right- and left- sides
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 20c35e12ffc97878dab7ed48b7e68dcdcbb35c09  | 
|--------|--------|

### Summary:
Added `TabDescriptor` component in `src/App.tsx` to display tabbed content with images and descriptions, with example data and potential improvements noted.

**Key points**:
- Added `TabDescriptor` component in `src/App.tsx` to display tabbed content with images and descriptions.
- Introduced `TabType` and `TabProps` types for tab data and props.
- Example tab data `tab_ex` added in `App` function.
- `TabDescriptor` allows switching between tabs and displays corresponding content.
- Potential improvements: text alignment with Figma spec, handling small photos as rectangles with rounded sides.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->